### PR TITLE
chore(rule): MEASURE_VALUE_NOT_NUMERIC rule is way too strict

### DIFF
--- a/src/ddf-rules/data-point-rules/measure-value-not-numeric.ts
+++ b/src/ddf-rules/data-point-rules/measure-value-not-numeric.ts
@@ -1,13 +1,14 @@
-import {MEASURE_VALUE_NOT_NUMERIC} from '../registry';
-import {LINE_NUM_INCLUDING_HEADER} from '../../ddf-definitions/constants';
-import {Issue} from '../issue';
+import { isEmpty } from 'lodash';
+import { MEASURE_VALUE_NOT_NUMERIC } from '../registry';
+import { LINE_NUM_INCLUDING_HEADER } from '../../ddf-definitions/constants';
+import { Issue } from '../issue';
 
 const parseDecimalNumber = require('parse-decimal-number');
 
 function isNotNumeric(valueParam) {
   const value = typeof valueParam === 'string' ? valueParam : `${valueParam}`;
 
-  return isNaN(parseDecimalNumber(value));
+  return isNaN(parseDecimalNumber(value)) && !isEmpty(value);
 }
 
 export const rule = {


### PR DESCRIPTION
DDF validation issue:

{"id":"MEASURE_VALUE_NOT_NUMERIC","type":"Measure in data point has not numeric type","path":"/Volumes/angie-data/GIT/csv-conf-2017-talk/data/ddf--bubbles-2/ddf--datapoints.csv","data":{"measure":"gdp_per_capita","line":54788,"value":""},"tags":["WARNING","DATAPOINT"]},

this rule also fires up when there are missing datapoints, as in, between two commas: ,,

this leads to flooding the console with pointless warnings because the case of missing data is very common

i suggest omitting the missing values

Closes #355