### PR TITLE
chore(rules): modify WRONG_ENTITY_IS_HEADER

### DIFF
--- a/src/ddf-rules/entity-rules/wrong-entity-is-header.ts
+++ b/src/ddf-rules/entity-rules/wrong-entity-is-header.ts
@@ -1,33 +1,62 @@
-import {includes, startsWith} from 'lodash';
-import {WRONG_ENTITY_IS_HEADER} from '../registry';
-import {DdfDataSet} from '../../ddf-definitions/ddf-data-set';
-import {Issue} from '../issue';
+import { includes, startsWith } from 'lodash';
+import { WRONG_ENTITY_IS_HEADER } from '../registry';
+import { DdfDataSet } from '../../ddf-definitions/ddf-data-set';
+import { Issue } from '../issue';
 import * as Levenshtein from 'levenshtein';
 
 const SUGGEST_TOLERANCE = 5;
 const IS_HEADER_PREFIX = 'is--';
 
+const getInformationAboutNonConcept = (ddfDataSet, actualHeaderDetail, headerDetail) =>
+  includes(ddfDataSet.getConcept().getIds(), actualHeaderDetail) ? null : {
+    message: 'Not a concept',
+    headerDetail
+  };
+
+const getInformationAboutWrongNonEntityConcept = (ddfDataSet, actualHeaderDetail, headerDetail) => {
+  const conceptRecord = ddfDataSet.getConcept().getRecordByKey(actualHeaderDetail);
+
+  return !conceptRecord || conceptRecord.concept_type !== 'entity_set' ? {
+    message: 'Wrong concept type',
+    headerDetail
+  } : null;
+};
+
+const getInformationForbiddenDomain = (ddfDataSet, actualHeader, fileDescriptor) => {
+  const domainTypeHash = ddfDataSet.getConcept().getDictionary(null, 'domain');
+  const primaryKeyDomain = domainTypeHash[fileDescriptor.primaryKey] || fileDescriptor.primaryKey;
+  const currentDomain = domainTypeHash[actualHeader];
+  const isCurrentDomainExists = includes(ddfDataSet.getConcept().getAllData().map(record => record.concept), currentDomain);
+
+  if (primaryKeyDomain === domainTypeHash[actualHeader] || !isCurrentDomainExists) {
+    return null;
+  }
+
+  return {
+    message: 'Forbidden domain for the entity set',
+    currentEntitySet: actualHeader,
+    currentDomain,
+    primaryKeyDomain
+  };
+};
+
+const getSuggestions = (ddfDataSet, actualHeader) => {
+  return ddfDataSet.getConcept().getDataIdsByType('entity_set')
+    .map(concept => {
+      const levenshtein = new Levenshtein(concept, actualHeader);
+
+      return {
+        concept,
+        distance: levenshtein.distance
+      };
+    })
+    .filter(suggest => suggest.distance < SUGGEST_TOLERANCE)
+    .map(suggest => suggest.concept);
+};
+
 export const rule = {
   rule: (ddfDataSet: DdfDataSet) => {
     const result = [];
-    const conceptIds = ddfDataSet.getConcept().getIds();
-    const entitySetIds = ddfDataSet.getConcept().getDataIdsByType('entity_set');
-
-    function getInformationAboutNonConcept(actualHeaderDetail, headerDetail) {
-      return includes(conceptIds, actualHeaderDetail) ? null : {
-        message: 'Not a concept',
-        headerDetail
-      };
-    }
-
-    function getInformationAboutWrongConcept(actualHeaderDetail, headerDetail) {
-      const conceptRecord = ddfDataSet.getConcept().getRecordByKey(actualHeaderDetail);
-
-      return !conceptRecord || conceptRecord.concept_type !== 'entity_set' ? {
-        message: 'Wrong concept type',
-        headerDetail
-      } : null;
-    }
 
     ddfDataSet.getEntity().fileDescriptors.forEach(fileDescriptor => {
       fileDescriptor.headers.forEach(header => {
@@ -36,22 +65,12 @@ export const rule = {
         if (startsWith(header, IS_HEADER_PREFIX)) {
           actualHeader = header.replace(IS_HEADER_PREFIX, '');
 
-          const data = getInformationAboutNonConcept(actualHeader, header) ||
-            getInformationAboutWrongConcept(actualHeader, header);
+          const data = getInformationAboutNonConcept(ddfDataSet, actualHeader, header) ||
+            getInformationAboutWrongNonEntityConcept(ddfDataSet, actualHeader, header) ||
+            getInformationForbiddenDomain(ddfDataSet, actualHeader, fileDescriptor);
 
           if (data) {
-            const suggestions =
-              entitySetIds
-                .map(concept => {
-                  const levenshtein = new Levenshtein(concept, actualHeader);
-
-                  return {
-                    concept,
-                    distance: levenshtein.distance
-                  };
-                })
-                .filter(suggest => suggest.distance < SUGGEST_TOLERANCE)
-                .map(suggest => suggest.concept);
+            const suggestions = getSuggestions(ddfDataSet, actualHeader);
             const issue = new Issue(WRONG_ENTITY_IS_HEADER)
               .setPath(fileDescriptor.fullPath)
               .setData(data)

--- a/test/entity-rules.spec.ts
+++ b/test/entity-rules.spec.ts
@@ -1,5 +1,5 @@
 import * as chai from 'chai';
-import { sortBy } from 'lodash';
+import { sortBy, head } from 'lodash';
 import { DdfDataSet } from '../src/ddf-definitions/ddf-data-set';
 import {
   WRONG_ENTITY_IS_HEADER,
@@ -25,11 +25,12 @@ describe('rules for entry', () => {
       });
     });
 
-    it(`issues should be found for folder with the problem
-    (fixtures/rules-cases/wrong-entity-is-header)`, done => {
+    it(`issues should be found for folder with next problems: 'Not a concept' and 'Wrong concept type'
+     (fixtures/rules-cases/wrong-entity-is-header)`, done => {
       ddfDataSet = new DdfDataSet('./test/fixtures/rules-cases/wrong-entity-is-header', null);
       ddfDataSet.load(() => {
         const result = allRules[WRONG_ENTITY_IS_HEADER].rule(ddfDataSet);
+
         const issuesData = [
           {
             message: 'Not a concept',
@@ -41,14 +42,37 @@ describe('rules for entry', () => {
           }
         ];
 
-        expect(result.length).to.equal(issuesData.length);
-
         issuesData.forEach((issueData, index) => {
           expect(result[index].type).to.equal(WRONG_ENTITY_IS_HEADER);
           expect(!!result[index].data).to.be.true;
           expect(result[index].data.message).to.equal(issueData.message);
           expect(result[index].data.headerDetail).to.equal(issueData.headerDetail);
         });
+
+        done();
+      });
+    });
+
+    it(`issues should be found for folder with next problem: 'Forbidden domain for the entity set'
+    (fixtures/rules-cases/wrong-entity-is-header-2)`, done => {
+      ddfDataSet = new DdfDataSet('./test/fixtures/rules-cases/wrong-entity-is-header-2', null);
+      ddfDataSet.load(() => {
+        const results = allRules[WRONG_ENTITY_IS_HEADER].rule(ddfDataSet);
+        const data = {
+          message: 'Forbidden domain for the entity set',
+          currentEntitySet: 'zzz',
+          currentDomain: 'xyz',
+          primaryKeyDomain: 'geo'
+        };
+        const result: Issue = <Issue>head(results);
+
+        expect(results.length).to.equal(1);
+        expect(result.type).to.equal(WRONG_ENTITY_IS_HEADER);
+        expect(!!result.data).to.be.true;
+        expect(result.data.message).to.equal(data.message);
+        expect(result.data.currentEntitySet).to.equal(data.currentEntitySet);
+        expect(result.data.currentDomain).to.equal(data.currentDomain);
+        expect(result.data.primaryKeyDomain).to.equal(data.primaryKeyDomain);
 
         done();
       });
@@ -66,7 +90,7 @@ describe('rules for entry', () => {
     });
 
     it(`issues should be found for folder with the problem
-    (fixtures/rules-cases/wrong-entity-is-value)`, done => {
+   (fixtures/rules-cases/wrong-entity-is-value)`, done => {
       ddfDataSet = new DdfDataSet('./test/fixtures/rules-cases/wrong-entity-is-value', null);
       ddfDataSet.load(() => {
         const result = allRules[WRONG_ENTITY_IS_VALUE].rule(ddfDataSet);
@@ -123,7 +147,7 @@ describe('rules for entry', () => {
     });
 
     it(`issues should be found for folder with the problem
-    (fixtures/rules-cases/non-unique-entity-value)`, done => {
+   (fixtures/rules-cases/non-unique-entity-value)`, done => {
       ddfDataSet = new DdfDataSet('./test/fixtures/rules-cases/non-unique-entity-value', null);
       ddfDataSet.load(() => {
         const results: Array<Issue> = allRules[NON_UNIQUE_ENTITY_VALUE].rule(ddfDataSet);
@@ -159,9 +183,7 @@ describe('rules for entry', () => {
           expect(!!resultsCopy[index].data.source).to.be.true;
           expect(!!resultsCopy[index].data.duplicate).to.be.true;
           expect(resultsCopy[index].data.source.geo).to.equal(issueData.source.geo);
-          expect(resultsCopy[index].data.source.name).to.equal(issueData.source.name);
           expect(resultsCopy[index].data.duplicate.geo).to.equal(issueData.duplicate.geo);
-          expect(resultsCopy[index].data.duplicate.name).to.equal(issueData.duplicate.name);
         });
 
         done();
@@ -180,7 +202,7 @@ describe('rules for entry', () => {
     });
 
     it(`issues should be found for folder with the problem
-    (fixtures/rules-cases/unexisting-constraint-value)`, done => {
+   (fixtures/rules-cases/unexisting-constraint-value)`, done => {
       ddfDataSet = new DdfDataSet('./test/fixtures/rules-cases/unexisting-constraint-value', null);
       ddfDataSet.load(() => {
         const result = allRules[UNEXISTING_CONSTRAINT_VALUE].rule(ddfDataSet);

--- a/test/fixtures/rules-cases/wrong-entity-is-header-2/ddf--concepts.csv
+++ b/test/fixtures/rules-cases/wrong-entity-is-header-2/ddf--concepts.csv
@@ -1,0 +1,11 @@
+concept,concept_type,domain,name
+name,string,,
+geo,entity_domain,,
+xyz,entity_domain,,
+region,entity_set,geo,Region
+country,entity_set,geo
+capital,entity_set,geo,Capital
+zzz,entity_set,xyz,Zzz
+pop,measure,geo,Population
+lat,measure,,Latitude
+lng,measure,,Longitude

--- a/test/fixtures/rules-cases/wrong-entity-is-header-2/ddf--entities--geo--country.csv
+++ b/test/fixtures/rules-cases/wrong-entity-is-header-2/ddf--entities--geo--country.csv
@@ -1,0 +1,2 @@
+geo,name,lat,lng,is--country,is--zzz
+and,Andorra,,,true,false


### PR DESCRIPTION
add case when all is- headers should be referenced by same domain
+ More strict: All is-- headers should refer a set in the domain of the primary key of the file

Closes #271