### PR TITLE
Fix bug in datapackage entity set primary key definition

### DIFF
--- a/src/data/data-package.ts
+++ b/src/data/data-package.ts
@@ -302,10 +302,9 @@ export class DataPackage {
       }
 
       if (fileDescriptor.type === ENTITY) {
-        const entityDomain = fileDescriptor.headers.find(header => conceptTypeHash[header] === CONCEPT_TYPE_ENTITY_DOMAIN);
-        const entitySet = fileDescriptor.headers.find(header => conceptTypeHash[header] === CONCEPT_TYPE_ENTITY_SET);
+        const [domain, set] = fileDescriptor.parts;
 
-        fileDescriptor.primaryKey = entityDomain || entitySet;
+        fileDescriptor.primaryKey = fileDescriptor.headers.indexOf(set) > -1 ? set : domain;
       }
 
       if (fileDescriptor.type === SYNONYM) {


### PR DESCRIPTION
Old logic was wrong.

file: `ddf--entities--geo--country.csv`
headers: `country, name, gender`
`country` is entity set, `gender` is entity domain
would give primary key `gender`

Updated logic handles this correctly.

Moreover, imagine you want to set a property `geo` on a `country` entity

with updated logic
in ddf--entities--geo.csv you can't because `geo` MUST be key
in ddf--entities--geo--country.csv you can because `country` will be key if used next to `geo`

defining `country` property on `geo` is still possible in ddf--entities--geo file or any other entity set file.
defining `geo` on `geo` is still impossible (was never possible) due to csv ambiguity.